### PR TITLE
Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,22 @@ Write some starting letters of the test file name to run
 the tests in that file.
 
 ```bash
-$ ./node_modules/.bin/loltest fo
+$ npx loltest fo
+# Runs test/foo.ts
+```
+
+### Reporters
+
+We bundle these reporters:
+
+- `loltest` *(default)*
+- `tap`
+- `dot`
+
+Choose between reporters with the `--reporter` CLI flag:
+
+```bash
+$ npx loltest --reporter=tap|dot|loltest
 ```
 
 # Layout

--- a/src/child.ts
+++ b/src/child.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { AssertionError } from 'assert';
-import { scan } from './main';
+import { scan } from "./lib/scan";
 import { Reporter } from './reporters';
 import LolTestReporter from './reporters/loltest-reporter';
 import { flatten } from './lib/flatten';

--- a/src/child.ts
+++ b/src/child.ts
@@ -143,7 +143,7 @@ export const runChild = async (conf: RunConf): Promise<void> => {
                     total: testsAsBooleans.length,
                     passed: testsAsBooleans.filter(p => p).length,
                     failed: testsAsBooleans.filter(p => !p).length,
-                    duration: (secsDiff * 1E3) + (nanoDiff / 1E3),
+                    duration: (secsDiff * 1E3) + (nanoDiff / 1E6),
                 },
             };
 

--- a/src/child.ts
+++ b/src/child.ts
@@ -43,7 +43,11 @@ interface Fail extends TestResult {
     error: Error;
 }
 
-export type Message = TestResultMessage | TestFinishedMessage | TestStartedMessage;
+export type Message =
+    | TestResultMessage
+    | TestFinishedMessage
+    | TestStartedMessage
+    | TestErrorMessage;
 
 export interface TestResultMessage {
     kind: 'test_result';
@@ -58,6 +62,11 @@ export interface TestFinishedMessage {
 export interface TestStartedMessage {
     kind: 'test_started';
     payload: ReporterStart;
+}
+
+export interface TestErrorMessage {
+    kind: 'test_error_message';
+    error?: Error;
 }
 
 // test() puts tests into here.

--- a/src/child.ts
+++ b/src/child.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import { AssertionError } from 'assert';
 import { scan } from './main';
+import { Reporter } from './reporters';
+import LolTestReporter from './reporters/loltest-reporter';
 
 export interface RunConf {
     target: string;
@@ -14,13 +16,22 @@ export interface TestRun {
     after?: (a?: any) => any;
 }
 
+interface TestFile {
+    filePath: string;
+    tests: TestRun[];
+}
+
 // test() puts tests into here.
 export const foundTests: TestRun[] = [];
+
+const flatten = <T>(arr: T[][]): T[] =>
+    Array.prototype.concat.apply([], arr);
 
 // Child process test runner
 export const runChild = async (conf: RunConf): Promise<void> => {
     // tslint:disable-next-line:no-let
     let uncaughtException = false, unhandledRejection = false;
+
     process.on('uncaughtException', (e) => {
         console.log('Uncaught exception:', e);
         uncaughtException = true;
@@ -30,90 +41,152 @@ export const runChild = async (conf: RunConf): Promise<void> => {
         unhandledRejection = true;
     });
 
-    const testPaths = getTestPaths(conf.target);
-    const allTests = testPaths.map(doTest);
+    const reporter = LolTestReporter;
+
+    const testFilePaths = getTestPaths(conf.target);
+
+    const testFiles: TestFile[] = testFilePaths.map<TestFile>(testPath => {
+        require(testPath);
+
+        return {
+            filePath: testPath,
+            tests: foundTests.splice(0, foundTests.length),
+        };
+    });
+
+    console.log(reporter.startRun({
+        numFiles: testFiles.length,
+        total: testFiles.reduce((acc, testFile) => acc + testFile.tests.length, 0),
+    }));
+
+    const allTests = testFiles.map((testFile) => doTest(testFile, reporter));
+
     Promise.all(allTests)
         .then((results) => {
-            const flat: boolean[] = Array.prototype.concat.apply([], results);
-            const allGood = flat.reduce((p: boolean, c) => p && c);
+            const flat: boolean[] = flatten(results);
+            const allGood = flat.reduce((p: boolean, c) => p && c, false);
             const clean = allGood && !uncaughtException && !unhandledRejection;
+
+            console.log(reporter.finishRun({
+                total: flat.length,
+                passed: flat.filter(p => p).length,
+                failed: flat.filter(p => !p).length,
+            }));
+
             process.exit(clean ? 0 : 1);
         });
 };
 
 const getTestPaths = (target: string): string[] => {
-    const stat = fs.statSync(target);
-    if (stat.isFile()) {
-        return [target];
-    } else if (stat.isDirectory()) {
-        return scan(target).map(n => path.join(target, n));
+    try {
+        const stat = fs.statSync(target);
+
+        if (stat.isFile()) {
+            return [target];
+        } else if (stat.isDirectory()) {
+            return scan(target).map(n => path.join(target, n));
+        }
+
+        throw new Error('Neither file nor directory');
+
+    } catch (err) {
+        console.error(`Cannot find directory: ${target}`);
+        return process.exit(1);
     }
-    console.error("Neither file nor directory", target);
-    return process.exit(1);
 };
 
-const doTest = (testPath: string): Promise<boolean[]> => {
-    const testFile = path.basename(testPath);
-    require(testPath);
-    const tests = foundTests.splice(0, foundTests.length);
-    if (tests.length) {
-        const all = tests.map(async ({ name, before, testfn, after }) => {
-            // run before and save the args
-            const args = await tryRun(testFile, name, 'BEFORE', before);
-            if (isFail(args)) {
-                // abort if BEFORE failed.
-                return false;
-            }
-            const testResult = await tryRun(testFile, name, '', () => testfn(args));
-            // always run AFTER, regardless of testResult.
-            await tryRun(testFile, name, 'AFTER', () => after && after(args));
-            if (!isFail(testResult)) {
-                console.log('✔︎', `${testFile}:`, name);
-                return true;
-            }
-            return false;
+const doTest = (testFile: TestFile, reporter: Reporter): Promise<boolean[]> => {
+    const testFileName = path.basename(testFile.filePath);
+    const tests = testFile.tests;
+
+    if (!tests.length) {
+        console.log(`${testFileName}:`, 'No tests found');
+        return Promise.resolve([]);
+    }
+
+    const all = tests.map(
+        async ({ name, before, testfn, after }, index): Promise<TestResult> => {
+
+        // run before and save the args
+        const args = await tryRun(testFileName, name, before);
+
+        if (isFail(args)) {
+            console.log(`Error before ${name} in ${testFileName}: ${formatError(args.error)}`);
+
+            return {
+                name,
+                fail: true,
+                error: args.error,
+            };
+        }
+
+        const testResult = await tryRun<TestResult>(testFileName, name, async () => {
+            await testfn(args);
+
+            return {
+                name,
+                fail: false,
+            };
         });
-        return Promise.all(all);
-    } else {
-        console.log(' ', `${testFile}:`, 'No tests found');
-    }
-    return Promise.resolve([]);
+
+        const report = reporter.test(testResult.name, {
+            index,
+            fileName: testFileName,
+            passed: !testResult.fail,
+            error: testResult.error,
+        });
+
+        // Main printout for this test
+        console.log(report);
+
+        // always run AFTER, regardless of testResult.
+        await tryRun(testFileName, name, () =>
+            after ? after(args).catch((err: any) => {
+                console.log(`Error after ${name} in ${testFileName}: ${formatError(err)}`);
+            }) : undefined
+        );
+
+        return testResult;
+    });
+
+    return Promise.all(all).then(results => results.map(r => !r.fail));
 };
 
-const Fail = {
-    fail: true,
-};
-const isFail = (t: any): t is typeof Fail => t === Fail;
+interface TestResult {
+    name: string;
+    fail: boolean;
+    error?: Error;
+}
+
+interface Fail extends TestResult {
+    fail: true;
+    error: Error;
+}
+
+const isFail = (t: any): t is Fail => !!t && !!t.fail;
 
 const tryRun = <T>(
     testFile: string,
     name: string,
-    phase: string,
     fn: (() => Promise<T>) | undefined,
-): Promise<T | typeof Fail> => Promise.resolve().then(fn)
-    .catch(e => {
-        const pfxname = phase ? `${phase} ${name}` : name;
-        const msg = errorMessage(testFile, pfxname, e);
-        console.log(...msg);
-        return Fail;
-    });
+): Promise<T | TestResult> => Promise.resolve().then(fn)
+    .catch((err): TestResult => ({
+        name,
+        fail: true,
+        error: err,
+    }));
 
-const ERR_PRELUDE = '\x1b[31m✗\x1b[0m';
-
-const errorMessage = (testFile: string, name: string, e: any): string[] => {
-    const msg = (() => {
-        if (e instanceof Error) {
-            if (e.stack) {
-                const c = e.stack.split('\n');
-                const t = e instanceof AssertionError ? e.message : c[0];
-                return [t, c[1]].join('\n');
-            } else {
-                return e.message;
-            }
+const formatError = (e: any): string => {
+    if (e instanceof Error) {
+        if (e.stack) {
+            const c = e.stack.split('\n');
+            const t = e instanceof AssertionError ? e.message : c[0];
+            return [t, c[1]].join('\n');
         } else {
-            return e;
+            return e.message;
         }
-    })();
-    return [ERR_PRELUDE, `[${testFile}: ${name}]`, msg];
+    }
+
+    return e;
 };
 

--- a/src/child.ts
+++ b/src/child.ts
@@ -4,6 +4,7 @@ import { AssertionError } from 'assert';
 import { scan } from './main';
 import { Reporter } from './reporters';
 import LolTestReporter from './reporters/loltest-reporter';
+import { flatten } from './lib/flatten';
 
 export interface RunConf {
     target: string;
@@ -44,9 +45,6 @@ interface Fail extends TestResult {
 
 // test() puts tests into here.
 export const foundTests: TestRun[] = [];
-
-const flatten = <T>(arr: T[][]): T[] =>
-    Array.prototype.concat.apply([], arr);
 
 // Child process test runner
 export const runChild = async (conf: RunConf): Promise<void> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { runMain } from './main';
 import { mkParseArgs } from './lib/parse-cli-args';
 
 const parseArgs = mkParseArgs({
-    '--tap': Boolean,
+    '--reporter': String,
 });
 
 /** Declare a test. */
@@ -88,6 +88,6 @@ if (runConf) {
     runMain(pathToSelf, {
         testDir,
         filter,
-        reporter: cliArgs['--tap'] ? 'tap' : 'loltest',
+        reporter: cliArgs['--reporter'],
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,8 +64,9 @@ if (runConf) {
             process.exit(1);
         });
 } else {
-    const self = argv[1]; // 0 is nodejs itself
+    const pathToSelf = argv[1]; // 0 is nodejs itself
     const testDir = path.join(process.cwd(), 'test');
     const filter = argv[2];
-    runMain(self, testDir, filter);
+
+    runMain(pathToSelf, testDir, filter);
 }

--- a/src/lib/colorize.ts
+++ b/src/lib/colorize.ts
@@ -1,0 +1,12 @@
+enum Color {
+    Green = "\x1b[32m",
+    Red = "\x1b[31m",
+    Reset = "\x1b[0m",
+}
+
+type ColorFn = (str: string) => string;
+
+export const colorize = (color: Color, str: string) => `${color}${str}${Color.Reset}`;
+
+export const red: ColorFn = colorize.bind(null, Color.Red);
+export const green: ColorFn = colorize.bind(null, Color.Green);

--- a/src/lib/flatten.ts
+++ b/src/lib/flatten.ts
@@ -1,0 +1,2 @@
+/** Flattens a multi dimensional array. */
+export const flatten = <T>(arr: T[][]): T[] => Array.prototype.concat.apply([], arr);

--- a/src/lib/is-plain-object.ts
+++ b/src/lib/is-plain-object.ts
@@ -1,0 +1,31 @@
+/*!
+ * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+function isObjectObject(o: any): boolean {
+    return o !== null && typeof o === 'object'
+        && Object.prototype.toString.call(o) === '[object Object]';
+}
+
+export function isPlainObject(o: any): boolean {
+
+    if (isObjectObject(o) === false) return false;
+
+    // If has modified constructor
+    const ctor = o.constructor;
+    if (typeof ctor !== 'function') return false;
+
+    // If has modified prototype
+    const prot = ctor.prototype;
+    if (isObjectObject(prot) === false) return false;
+
+    // If constructor does not have an Object-specific method
+    if (prot.hasOwnProperty('isPrototypeOf') === false) {
+        return false;
+    }
+
+    // Most likely a plain Object
+    return true;
+}

--- a/src/lib/parse-cli-args.ts
+++ b/src/lib/parse-cli-args.ts
@@ -36,14 +36,16 @@ export const mkParseArgs = <S extends Spec>(spec: S) =>
 
         return Object.assign.apply(null, argv
             .map((arg, idx, arr) => {
-                if (arg in handlers) {
-                    const handler = handlers[arg];
+                const [argName, value] = arg.split('=');
+
+                if (argName in handlers) {
+                    const handler = handlers[argName];
                     // Flags have no value, treat as 'true'
                     const isFlag = handler === Boolean;
                     // Grab next arg in position
-                    const argValue = isFlag ? 'true' : argv[idx + 1];
+                    const argValue = isFlag ? 'true' : value;
 
-                    return { [arg]: handler(argValue) };
+                    return { [argName]: handler(argValue) };
                 }
 
                 return {};

--- a/src/lib/parse-cli-args.ts
+++ b/src/lib/parse-cli-args.ts
@@ -1,0 +1,52 @@
+type Handler = (value: string) => any;
+
+interface Spec {
+    [key: string]: Handler;
+}
+
+type Result<S extends Spec> = {
+    [K in keyof S]?: ReturnType<S[K]>;
+};
+
+/** Create a parser for string arguments, often `process.argv`. */
+export const mkParseArgs = <S extends Spec>(spec: S) =>
+    (argv: string[]): Result<S> => {
+        const handlers: {[key: string]: Handler} = {};
+
+        for (const key of Object.keys(spec)) {
+            if (!key) {
+                throw new TypeError('Argument key cannot be empty string!');
+            }
+
+            if (!key.startsWith('--')) {
+                throw new TypeError('Argument key must start with --!');
+            }
+
+            if (key.length === 2) {
+                throw new TypeError('Argument key must have a real name!');
+            }
+
+            // tslint:disable-next-line no-object-mutation
+            handlers[key] = spec[key];
+        }
+
+        if (!argv.length) {
+            return {};
+        }
+
+        return Object.assign.apply(null, argv
+            .map((arg, idx, arr) => {
+                if (arg in handlers) {
+                    const handler = handlers[arg];
+                    // Flags have no value, treat as 'true'
+                    const isFlag = handler === Boolean;
+                    // Grab next arg in position
+                    const argValue = isFlag ? 'true' : argv[idx + 1];
+
+                    return { [arg]: handler(argValue) };
+                }
+
+                return {};
+            })
+        );
+    };

--- a/src/lib/scan.ts
+++ b/src/lib/scan.ts
@@ -1,0 +1,7 @@
+import fs from 'fs';
+
+// TODO: recursive dir scanning
+export const scan = (dir: string): string[] => {
+    const allFiles = fs.readdirSync(dir);
+    return allFiles.filter(n => !n.startsWith('_') && (n.endsWith('ts') || n.endsWith('js')));
+};

--- a/src/lib/serialize-error.ts
+++ b/src/lib/serialize-error.ts
@@ -1,0 +1,18 @@
+export interface SerializedError {
+    message: string;
+    name: string;
+    stack?: string;
+    code?: string;
+}
+
+const isPrimitive = (val: any) =>
+    ['number', 'string', 'boolean'].includes(typeof val);
+
+/** Serialize and Error to a plain object, keeping commonly used properties. */
+export const serializeError = <T extends SerializedError>(err: Error, props?: string[]): T =>
+    Object.assign.apply(null, (['name', 'message', 'stack', 'code'].concat(props || [])
+        // Filter out unwanted
+        .filter(k => isPrimitive((err as any)[k]))
+        // Create new object array and spread the array on the return object
+        .map((k: keyof Error) => ({ [k]: err[k] })))
+    );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,46 @@
 import child_process from 'child_process';
 import path from 'path';
 import { scan } from './lib/scan';
+import { Message } from './child';
+import LolTestReporter from './reporters/loltest-reporter';
+import { Reporter } from './reporters';
 
 /** The main process which forks child processes for each test. */
 export const runMain = (self: string, testDir: string, filter: string) => {
     const target = findTarget(testDir, filter);
-    const child = child_process.fork(self, ['--child-runner', target]);
-    child.addListener('exit', childExit => {
+    const params = ['--child-runner', target];
+
+    const reporter = LolTestReporter;
+
+    const child = child_process.fork(self, params, {
+        // See https://nodejs.org/api/child_process.html#child_process_options_stdio
+        // We pipe stdin, stdout, stderr between the parent and child process,
+        // and enable IPC (Inter Process Communication) to pass messages.
+        stdio: [ process.stdin, process.stdout, process.stderr, 'ipc' ],
+    });
+
+    child.on('message', (m: Message) => handleChildMessage(reporter, m));
+
+    child.on('exit', childExit => {
         // die when child dies.
         const code = childExit ? childExit : 0;
         process.exit(code);
     });
+};
+
+const handleChildMessage = (reporter: Reporter, message: Message) => {
+    switch (message.kind) {
+        case 'test_started':
+            console.log(reporter.startRun(message.payload));
+            return;
+        case 'test_result':
+            console.log(reporter.test(message.payload));
+            return;
+        case 'test_finished':
+            console.log(reporter.finishRun(message.payload));
+            return;
+    }
+    ((x: never) => { })(message); // assert exhaustive
 };
 
 /** Find a target to start child process from. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,9 @@ const handleChildMessage = (reporter: Reporter, message: Message) => {
         case 'test_finished':
             console.log(reporter.finishRun(message.payload));
             return;
+        case 'test_error_message':
+            console.error(reporter.bail(message.error && message.error.message));
+            return;
     }
     ((x: never) => { })(message); // assert exhaustive
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,16 @@ import child_process from 'child_process';
 import path from 'path';
 import { scan } from './lib/scan';
 import { Message } from './child';
-import LolTestReporter from './reporters/loltest-reporter';
 import { Reporter } from './reporters';
+import TAPReporter from './reporters/tap-reporter';
+import LolTestReporter from './reporters/loltest-reporter';
 
 /** The main process which forks child processes for each test. */
 export const runMain = (self: string, testDir: string, filter: string) => {
     const target = findTarget(testDir, filter);
     const params = ['--child-runner', target];
 
-    const reporter = LolTestReporter;
+    const reporter = TAPReporter;
 
     const child = child_process.fork(self, params, {
         // See https://nodejs.org/api/child_process.html#child_process_options_stdio

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import child_process from 'child_process';
-import fs from 'fs';
 import path from 'path';
+import { scan } from './lib/scan';
 
 /** The main process which forks child processes for each test. */
 export const runMain = (self: string, testDir: string, filter: string) => {
@@ -28,9 +28,4 @@ export const findTarget = (testDir: string, filter: string): string => {
     return testDir;
 };
 
-// TODO: recursive dir scanning
-export const scan = (dir: string): string[] => {
-    const allFiles = fs.readdirSync(dir);
-    return allFiles.filter(n => !n.startsWith('_') && (n.endsWith('ts') || n.endsWith('js')));
-};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,8 @@ const handleChildMessage = (reporter: Reporter, message: Message) => {
             console.log(reporter.startRun(message.payload));
             return;
         case 'test_result':
-            console.log(reporter.test(message.payload));
+            const output = reporter.test(message.payload);
+            output && process.stdout.write(output);
             return;
         case 'test_finished':
             console.log(reporter.finishRun(message.payload));

--- a/src/reporters/dot-reporter.ts
+++ b/src/reporters/dot-reporter.ts
@@ -1,0 +1,17 @@
+import { Reporter } from ".";
+import { red } from "../lib/colorize";
+
+const DotReporter: Reporter = {
+    startRun: ({ numFiles, total }) => '',
+
+    test: ({ title, passed, index, error, duration }) =>
+        passed ? '.' : red('.'),
+
+    // "Ran X tests. Y passed, Z failed"
+    finishRun: ({ total, passed, failed, duration }) =>
+        `\n\n${passed}/${total} in ${duration} ms`,
+
+    bail: reason => '',
+};
+
+export default DotReporter;

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -1,0 +1,32 @@
+interface ReporterTestOptions {
+    /** What order does this test have? */
+    index: number;
+    /** Indicates whether the test passed or not */
+    passed: boolean;
+    /** The filename of this test */
+    fileName: string;
+    /** Optional error if `passed` is true */
+    error?: Error;
+}
+
+interface ReporterStats {
+    /** Total number of tests */
+    total: number;
+    /** Total passed tests */
+    passed: number;
+    /** Total failed tests */
+    failed: number;
+}
+
+type ReporterOutput = string | undefined;
+
+export interface Reporter {
+    /** Call before test run starts */
+    startRun: (opts: { total: number, numFiles: number }) => ReporterOutput;
+
+    /** Call for each test case */
+    test: (title: string, opts: ReporterTestOptions) => ReporterOutput;
+
+    /** Call after test run ends */
+    finishRun: (stats: ReporterStats) => ReporterOutput;
+}

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -1,15 +1,24 @@
-interface ReporterTestOptions {
+import { SerializedError } from "../lib/serialize-error";
+
+export interface ReporterStart {
+    total: number;
+    numFiles: number;
+}
+
+export interface TestCaseReport {
+    /** The name of the test case */
+    title: string;
     /** What order does this test have? */
     index: number;
     /** Indicates whether the test passed or not */
     passed: boolean;
     /** The filename of this test */
     fileName: string;
-    /** Optional error if `passed` is true */
-    error?: Error;
+    /** Error, if `passed` is false */
+    error?: Error | SerializedError;
 }
 
-interface ReporterStats {
+export interface ReporterStats {
     /** Total number of tests */
     total: number;
     /** Total passed tests */
@@ -18,14 +27,14 @@ interface ReporterStats {
     failed: number;
 }
 
-type ReporterOutput = string | undefined;
+export type ReporterOutput = string | undefined;
 
 export interface Reporter {
     /** Call before test run starts */
-    startRun: (opts: { total: number, numFiles: number }) => ReporterOutput;
+    startRun: (opts: ReporterStart) => ReporterOutput;
 
     /** Call for each test case */
-    test: (title: string, opts: ReporterTestOptions) => ReporterOutput;
+    test: (opts: TestCaseReport) => ReporterOutput;
 
     /** Call after test run ends */
     finishRun: (stats: ReporterStats) => ReporterOutput;

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -38,4 +38,6 @@ export interface Reporter {
 
     /** Call after test run ends */
     finishRun: (stats: ReporterStats) => ReporterOutput;
+
+    bail: (reason?: string) => ReporterOutput;
 }

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -16,6 +16,8 @@ export interface TestCaseReport {
     fileName: string;
     /** Error, if `passed` is false */
     error?: Error | SerializedError;
+    /** Duration to run this test, in milliseconds */
+    duration: number;
 }
 
 export interface ReporterStats {
@@ -25,6 +27,8 @@ export interface ReporterStats {
     passed: number;
     /** Total failed tests */
     failed: number;
+    /** Duration in milliseconds */
+    duration: number;
 }
 
 export type ReporterOutput = string | undefined;

--- a/src/reporters/loltest-reporter.ts
+++ b/src/reporters/loltest-reporter.ts
@@ -1,18 +1,6 @@
 import { Reporter } from ".";
 import { SerializedError } from "../lib/serialize-error";
-
-enum Color {
-    Green = "\x1b[32m",
-    Red = "\x1b[31m",
-    Reset = "\x1b[0m",
-}
-
-type ColorFn = (str: string) => string;
-
-const colorize = (color: Color, str: string) => `${color}${str}${Color.Reset}`;
-
-const red: ColorFn = colorize.bind(null, Color.Red);
-const green: ColorFn = colorize.bind(null, Color.Green);
+import { green, red } from "../lib/colorize";
 
 const formatError = (err: Error | SerializedError): string => {
     if (err.stack) {

--- a/src/reporters/loltest-reporter.ts
+++ b/src/reporters/loltest-reporter.ts
@@ -64,9 +64,9 @@ const LolTestReporter: Reporter = {
     },
 
     // "Ran X tests. Y passed, Z failed"
-    finishRun: ({ total, passed, failed }) => {
+    finishRun: ({ total, passed, failed, duration }) => {
         return [
-            `\nRan ${total} ${pluralize('test', total)} –`,
+            `\nRan ${total} ${pluralize('test', total)} in ${duration} ms –`,
             `${passed ? green(passed + ' passed') : passed + ' passed'}, ${
                 failed ? red(failed + ' failed') : failed + ' failed'}`,
         ].join(' ');

--- a/src/reporters/loltest-reporter.ts
+++ b/src/reporters/loltest-reporter.ts
@@ -16,7 +16,7 @@ const logSuccess = (title: string, fileName: string) =>
     `${green("✔︎")} ${fileName}: ${title}`;
 
 const logFail = (title: string, fileName: string, error?: Error) =>
-    `${red("✗")} ${fileName}: ${title}\n${error && formatError(error)}`;
+    `${red("✗")} ${fileName}: ${title}\n${error && formatError(error)}\n`;
 
 const pluralize = (noun: string, count: number) =>
     count > 1 ? `${noun}s` : noun;
@@ -46,18 +46,18 @@ const LolTestReporter: Reporter = {
             pluralize('file', numFiles)}...`,
 
     test: ({title, passed, fileName, error }) => {
-        return passed
+        return '\n' + (passed
             ? logSuccess(title, fileName)
-            : logFail(title, fileName, error);
+            : logFail(title, fileName, error));
     },
 
     // "Ran X tests. Y passed, Z failed"
     finishRun: ({ total, passed, failed, duration }) => {
         return [
-            `\nRan ${total} ${pluralize('test', total)} in ${duration} ms –`,
+            `\nRan ${total} ${pluralize('test', total)} in ${duration} ms`,
             `${passed ? green(passed + ' passed') : passed + ' passed'}, ${
                 failed ? red(failed + ' failed') : failed + ' failed'}`,
-        ].join(' ');
+        ].join('\n');
     },
 
     bail: (reason) =>

--- a/src/reporters/loltest-reporter.ts
+++ b/src/reporters/loltest-reporter.ts
@@ -1,0 +1,80 @@
+import { Reporter } from ".";
+import { AssertionError } from "assert";
+
+enum Color {
+    Green = "\x1b[32m",
+    Red = "\x1b[31m",
+    Reset = "\x1b[0m",
+}
+
+type ColorFn = (str: string) => string;
+
+const colorize = (color: Color, str: string) => `${color}${str}${Color.Reset}`;
+
+const red: ColorFn = colorize.bind(null, Color.Red);
+const green: ColorFn = colorize.bind(null, Color.Green);
+
+const serializeError = (err: any) => {
+    if (err instanceof Error) {
+        if (err.stack) {
+            const c = err.stack.split("\n");
+            const t = err instanceof AssertionError ? err.message : c[0];
+            return [t, c[1]].join('\n');
+        } else {
+            return err.message;
+        }
+    }
+
+    return err;
+};
+
+const logSuccess = (title: string, fileName: string) =>
+    `${green("✔︎")} ${fileName}: ${title}`;
+
+const logFail = (title: string, fileName: string, error?: Error) =>
+    `${red("✗")} ${fileName}: ${title}\n${serializeError(error)}`;
+
+const pluralize = (noun: string, count: number) =>
+    count > 1 ? `${noun}s` : noun;
+
+/**
+ * A plain reporter.
+ *
+ * Sample output:
+ *
+ ```bash
+Found 4 tests in 2 files...
+✗ test-file.ts: This fails
+2 == 4
+    at __1.test (/Users/brookie/Projects/Code/lookback/loltest/test/test-file.ts:9:12)
+✗ test-file.ts: Deep equal
+{ foo: 'bar' } deepEqual { bar: 'foo' }
+    at __1.test (/Users/brookie/Projects/Code/lookback/loltest/test/test-file.ts:13:12)
+✔︎ another-test.ts: Another
+✔︎ test-file.ts: It works
+
+Ran 4 tests – 2 passed, 2 failed
+```
+ */
+const LolTestReporter: Reporter = {
+    startRun: ({ total, numFiles }) =>
+        `Found ${total} ${pluralize('test', total)} in ${numFiles} ${
+            pluralize('file', numFiles)}...`,
+
+    test: (title, { passed, fileName, error }) => {
+        return passed
+            ? logSuccess(title, fileName)
+            : logFail(title, fileName, error);
+    },
+
+    // "Ran X tests. Y passed, Z failed"
+    finishRun: ({ total, passed, failed }) => {
+        return [
+            `\nRan ${total} ${pluralize('test', total)} –`,
+            `${passed ? green(passed + ' passed') : passed + ' passed'}, ${
+                failed ? red(failed + ' failed') : failed + ' failed'}`,
+        ].join(' ');
+    },
+};
+
+export default LolTestReporter;

--- a/src/reporters/loltest-reporter.ts
+++ b/src/reporters/loltest-reporter.ts
@@ -71,6 +71,9 @@ const LolTestReporter: Reporter = {
                 failed ? red(failed + ' failed') : failed + ' failed'}`,
         ].join(' ');
     },
+
+    bail: (reason) =>
+        `${red('An error occurred!')}\n${reason}`,
 };
 
 export default LolTestReporter;

--- a/src/reporters/tap-reporter.ts
+++ b/src/reporters/tap-reporter.ts
@@ -11,6 +11,10 @@ const TAPReporter: Reporter = {
     finishRun: () => {
         return '';
     },
+
+    bail: (reason) =>
+        // This is lol: http://testanything.org/tap-version-13-specification.html#bail-out
+        `Bail out! ${reason}`,
 };
 
 export default TAPReporter;

--- a/src/reporters/tap-reporter.ts
+++ b/src/reporters/tap-reporter.ts
@@ -1,12 +1,64 @@
+import { basename } from 'path';
 import { Reporter } from ".";
+import { SerializedError } from "../lib/serialize-error";
+import { isPlainObject } from "../lib/is-plain-object";
+
+const getStackInfo = (stack: string): { line?: string, column?: string, file: string } | string => {
+    const stackArr = stack.split('\n');
+    const stackLine = stackArr[0].includes('ERR_ASSERTION')  ? stackArr[1] : stackArr[0];
+    const match = stackLine.match(/\((\/.*)\)/);
+
+    if (!match) {
+        return stackLine;
+    }
+
+    const base = basename(match[1]);
+    const [, file, line, column]: string[] = base.match(/(.*):(\d+):(\d+)/) || [];
+
+    return { file, line, column };
+};
+
+const formatError = (error: SerializedError): object => {
+    const stack = error.stack ? getStackInfo(error.stack) : undefined;
+
+    return {
+        error: error.name,
+        message: error.message,
+        at: stack ? stack : undefined,
+    };
+};
+
+const toYAML = (obj: object, indent = 0): string =>
+    Object.entries(obj)
+        .map(
+            ([key, val]) =>
+                `${' '.repeat(indent)}${key}: ${
+                isPlainObject(val)
+                    ? `\n${toYAML(val, indent + 3)}`
+                    : String(val)
+                }`
+        )
+        .join(`\n`);
+
+const outputDiagnostics = (obj: any): string =>
+    `
+   ---
+${toYAML(obj, 3)}
+   ...
+`;
+
+const logSuccess = (title: string, index: number) =>
+    `ok ${index + 1} - ${title}`;
+
+const logFailure = (title:  string, index: number, error?: SerializedError) =>
+    `not ok ${index + 1} - ${title}` + (error ? outputDiagnostics(formatError(error)) : '');
 
 const TAPReporter: Reporter = {
     startRun: ({ numFiles, total }) =>
         `TAP version 13\n1..${total}`,
 
-    test: ({ title, passed, index }) => {
-        return `${passed ? '': 'not '}ok ${index + 1} ${title}`;
-    },
+    test: ({ title, passed, index, error }) =>
+        passed ? logSuccess(title, index) : logFailure(title, index, error),
 
     finishRun: () => {
         return '';

--- a/src/reporters/tap-reporter.ts
+++ b/src/reporters/tap-reporter.ts
@@ -1,0 +1,16 @@
+import { Reporter } from ".";
+
+const TAPReporter: Reporter = {
+    startRun: ({ numFiles, total }) =>
+        `TAP version 13\n1..${total}`,
+
+    test: ({ title, passed, index }) => {
+        return `${passed ? '': 'not '}ok ${index + 1} ${title}`;
+    },
+
+    finishRun: () => {
+        return '';
+    },
+};
+
+export default TAPReporter;

--- a/src/reporters/tap-reporter.ts
+++ b/src/reporters/tap-reporter.ts
@@ -60,7 +60,7 @@ const TAPReporter: Reporter = {
     startRun: ({ numFiles, total }) => `TAP version 13\n1..${total}`,
 
     test: ({ title, passed, index, error, duration }) =>
-        (passed ? logSuccess(title, index) : logFailure(title, index, error)) +
+        '\n' + (passed ? logSuccess(title, index) : logFailure(title, index, error)) +
         outputDirectives({ duration }),
 
     finishRun: () => {

--- a/src/reporters/tap-reporter.ts
+++ b/src/reporters/tap-reporter.ts
@@ -53,18 +53,21 @@ const logSuccess = (title: string, index: number) =>
 const logFailure = (title:  string, index: number, error?: SerializedError) =>
     `not ok ${index + 1} - ${title}` + (error ? outputDiagnostics(formatError(error)) : '');
 
-const TAPReporter: Reporter = {
-    startRun: ({ numFiles, total }) =>
-        `TAP version 13\n1..${total}`,
+const outputDirectives = ({duration}: { duration: number  }) =>
+    `${duration !== 0 ? ' # time=' + duration + 'ms': ''}`;
 
-    test: ({ title, passed, index, error }) =>
-        passed ? logSuccess(title, index) : logFailure(title, index, error),
+const TAPReporter: Reporter = {
+    startRun: ({ numFiles, total }) => `TAP version 13\n1..${total}`,
+
+    test: ({ title, passed, index, error, duration }) =>
+        (passed ? logSuccess(title, index) : logFailure(title, index, error)) +
+        outputDirectives({ duration }),
 
     finishRun: () => {
-        return '';
+        return "";
     },
 
-    bail: (reason) =>
+    bail: reason =>
         // This is lol: http://testanything.org/tap-version-13-specification.html#bail-out
         `Bail out! ${reason}`,
 };

--- a/test/another-test.ts
+++ b/test/another-test.ts
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import { test } from '../';
+
+test('Another', () => {
+    assert.equal(2, 2);
+});

--- a/test/parse-args.ts
+++ b/test/parse-args.ts
@@ -1,0 +1,29 @@
+import assert from 'assert';
+import { test } from '../';
+import { mkParseArgs } from '../src/lib/parse-cli-args';
+
+test('Parse args from an array', () => {
+    const parse = mkParseArgs({
+        '--foo': String,
+        '--switch': Boolean,
+        '--count': Number,
+    });
+
+    const result = parse(['--count', '3', '--switch', '--foo', 'lol']);
+
+    assert.deepEqual(result, {
+        '--count': 3,
+        '--foo': 'lol',
+        '--switch': true,
+    });
+});
+
+test('Parse empty args array', () => {
+    const parse = mkParseArgs({
+        '--foo': String,
+    });
+
+    const res = parse([]);
+
+    assert.ok(res);
+});

--- a/test/parse-args.ts
+++ b/test/parse-args.ts
@@ -9,7 +9,7 @@ test('Parse args from an array', () => {
         '--count': Number,
     });
 
-    const result = parse(['--count', '3', '--switch', '--foo', 'lol']);
+    const result = parse(['--count=3', '--switch', '--foo=lol']);
 
     assert.deepEqual(result, {
         '--count': 3,

--- a/test/test-file.ts
+++ b/test/test-file.ts
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { test } from '../';
+
+test('It works', () => {
+    assert.equal(2, 2);
+});
+
+test('This fails', () => {
+    assert.equal(2, 4);
+});
+
+test('Deep equal', () => {
+    assert.deepEqual({ foo: 'bar' }, { bar: 'foo' });
+});


### PR DESCRIPTION
- [x] No dependencies added
- [x] TAP reporter
- [x] Add CLI arg `--tap` to select TAP output

This PR adds some basic functionality for plugging in other reporters. It's a building block for implementing a TAP reporter for loltest (https://testanything.org/tap-version-13-specification.html). TAP is nice for outputting tests results from this lib to other services.

Right now, I've implemented the default `LoltestReporter` as pretty dumb: it doesn't count tests or anything by itself. It could be modified into counting total files, tests, passed, failed itself without having `child.ts` know about that. But it's pretty nice with a reporter being just plain functions too :) Downside is that `child.ts` needs to accommodate for all needs of reporters.

Sample output with default `LoltestReporter`:

<img width="711" alt="skarmavbild 2019-01-29 kl 23 36 38" src="https://user-images.githubusercontent.com/30257156/51946007-9d697b80-2420-11e9-89d3-1949823b9e3f.png">
